### PR TITLE
[SOLUTION] Lesson 1: Setting up and Locally Invoking Lambda Handler(s) 🦾

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,12 +2,20 @@ service: serverless
 
 provider:
   name: aws
-  runtime: nodejs8.10
-  profile: femasters
+  runtime: nodejs16.x
+  # profile: femasters
   region: us-west-1
   stage: dev
 
-plugins:
-  - serverless-offline
+# plugins:
+#   - serverless-offline
 
+functions:
+  # NB. the name of the functions here do *not* have to match filenames where handler is stored
+  hello:
+    # NB.2 however the handler nested syntax has to match what the exported module is named
+    handler: src/helloworld.handler
+  bye:
+  # NB.3 notice the .lambda here, since byeworld.js is exporting `exports.module.lambda`
+    handler: src/byeworld.lambda
     

--- a/src/byeworld.js
+++ b/src/byeworld.js
@@ -1,0 +1,12 @@
+module.exports.lambda = ( evt, ctx, callback ) => {
+    const response = {
+        statusCode: 200,
+        body: {
+            input: evt,
+            context: ctx,
+            message: 'bye!',
+        }
+    };
+    console.log(response)
+    callback(null, 'lambda has been invoked');
+};

--- a/src/event.json
+++ b/src/event.json
@@ -1,3 +1,3 @@
 {
-  "message": "hello"
+  "message": "this message will be visible in the console when this event is passed into local serverless invoke command with -p"
 }

--- a/src/helloworld.js
+++ b/src/helloworld.js
@@ -1,3 +1,13 @@
 module.exports.handler = (evt, ctx, done) => {
-  
-}
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify({
+            message: 'This message indicates lesson 1 was completed successfully! 😎',
+            input: evt,
+            context: ctx,
+        })
+    };
+
+    console.log(response)
+    done(null, 'hello!')
+};


### PR DESCRIPTION
1) Set up `functions` parameter in Serverless template file `serverless.yml` to point Serverless to the existing handler stored in `helloworld.js`

2) Initialised `response` object of the helloworld handler, and finished lambda logic by invoking within it a callback function to terminate the lambda invocation

3) Created a new handler function stored in `src/byeworld.js` file, and added the function to the Serverless template. 

NB. To run each of the handler functions locally:
1) first I had to install `serverless` locally: 
    - `npm i -g serverless`
2) then I used the invoke command within project `:root`, passing in the `-f` flag with the name of the handler function (as specified in the Serverless template): 
    - `svs invoke local -f hello` or `svs invoke local -f bye`
3) BONUS: to pass in the statically initialised event object to the local handler invocation, added an additional `-p` flag with the path to the file in which event object is stored: 
    - `svs invoke -f hello -p src/event.json`

Passing in the `event` object, the output in the Terminal: 

`svs invoke -f bye -p src/event.json`

```
{
  statusCode: 200,
  body: {
    input: {
      message: 'this message will be visible in the console when this event is passed into local serverless invoke command with -p'
    },
    context: {
      awsRequestId: '6a6343e6-de03-41c9-a446-0f9ced352f73',
      invokeid: 'id',
      logGroupName: '/aws/lambda/serverless-dev-bye',
      logStreamName: '2015/09/22/[HEAD]13370a84ca4ed8b77c427af260',
      functionVersion: 'HEAD',
      isDefaultFunctionVersion: true,
      functionName: 'serverless-dev-bye',
      memoryLimitInMB: '1024',
      succeed: [Function: succeed],
      fail: [Function: fail],
      done: [Function: done],
      getRemainingTimeInMillis: [Function: getRemainingTimeInMillis]
    },
    message: 'bye!'
  }
}
"lambda has been invoked"
```

PS. `context` (or `ctx`) here refers to the context/environment in which this lambda function is invoked within AWS (and includes potentially useful metadata)
